### PR TITLE
feature(add-init-commands): Add init commands to Agent Config

### DIFF
--- a/.github/workflows/nx-cloud-agents.yml
+++ b/.github/workflows/nx-cloud-agents.yml
@@ -21,6 +21,9 @@ on:
       install-command:
         required: false
         type: string
+      init-commands:
+        required: false
+        type: string
 
 env:
   NX_CLOUD_DISTRIBUTED_EXECUTION: true
@@ -131,6 +134,13 @@ jobs:
             echo "Running npm ci"
             npm ci
           fi
+      # The good thing about the multi-line string input for sequential commands is that we can simply forward it on as is to the bash shell and it will behave
+      # how we want it to in terms of quote escaping, variable assignment etc
+      - name: Run any configured init-commands sequentially
+        if: ${{ inputs.init-commands != '' }}
+        shell: bash
+        run: |
+          ${{ inputs.init-commands }}
 
       - name: Start Nx Agent ${{ matrix.agent }}
         run: npx nx-cloud start-agent


### PR DESCRIPTION
Agents can leverage the ability to configure an init commands.

I think this is all that needs to be done. But I'm not entirely sure if the utils stuff is necessary to run commands beyond what I have in my scope. You can let me know if I'm missing some important parts to this.

#5 that I made. 