### PR TITLE
feat!: support multi-line custom install-commands

### DIFF
--- a/.github/workflows/ci-integration-test-install-command.yml
+++ b/.github/workflows/ci-integration-test-install-command.yml
@@ -1,0 +1,51 @@
+name: CI - integration test install-command input
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  main:
+    name: Nx Cloud - Main Job
+    uses: ./.github/workflows/nx-cloud-main.yml
+    with:
+      working-directory: ./integration-tests/npm
+      install-command: |
+        echo "Installing dependencies with custom install-command"
+        npm ci
+        touch ./install-command-success
+        echo "install command end"
+      parallel-commands: |
+        FILE=./install-command-success
+        if [ -f "$FILE" ]; then
+        echo "install-command success"
+        else
+          echo "fail: install-command did not run."
+          exit 1
+        fi
+        npx nx workspace-lint
+        npx nx format:check
+      parallel-commands-on-agents: |
+        FILE=./install-command-success
+        if [ -f "$FILE" ]; then
+          echo "install-command success"
+        else
+          echo "fail: install-command did not run."
+          exit 1
+        fi
+        npx nx affected --target=lint --parallel=3
+        npx nx affected --target=test --parallel=3 --ci --code-coverage
+        npx nx affected --target=build --parallel=3
+
+  agents:
+    name: Nx Cloud - Agents
+    uses: ./.github/workflows/nx-cloud-agents.yml
+    with:
+      working-directory: ./integration-tests/npm
+      number-of-agents: 3

--- a/.github/workflows/ci-integration-test-install-commands.yml
+++ b/.github/workflows/ci-integration-test-install-commands.yml
@@ -19,26 +19,14 @@ jobs:
       install-commands: |
         echo "Installing dependencies with custom install-commands"
         npm ci
-        touch ./install-command-success
-        echo "install command end"
+        touch ./install-commands-success
+        echo "install commands end"
       parallel-commands: |
-        FILE=./install-command-success
-        if [ -f "$FILE" ]; then
-        echo "install-command success"
-        else
-          echo "fail: install-command did not run."
-          exit 1
-        fi
+        node -e "const f = require('fs'); if(f.existsSync('./install-commands-success')) console.log('install-commands success'); else { throw new Error('install commands did not run!');}"
         npx nx workspace-lint
         npx nx format:check
       parallel-commands-on-agents: |
-        FILE=./install-command-success
-        if [ -f "$FILE" ]; then
-          echo "install-command success"
-        else
-          echo "fail: install-command did not run."
-          exit 1
-        fi
+        node -e "const f = require('fs'); if(f.existsSync('./install-commands-success')) console.log('install-commands success on agent.'); else { throw new Error('install commands did not run!');}"
         npx nx affected --target=lint --parallel=3
         npx nx affected --target=test --parallel=3 --ci --code-coverage
         npx nx affected --target=build --parallel=3
@@ -52,5 +40,5 @@ jobs:
       install-commands: |
         echo "Installing dependencies with custom install-commands"
         npm ci
-        touch ./install-command-success
-        echo "install command end"
+        touch ./install-commands-success
+        echo "install commands end"

--- a/.github/workflows/ci-integration-test-install-commands.yml
+++ b/.github/workflows/ci-integration-test-install-commands.yml
@@ -16,8 +16,8 @@ jobs:
     uses: ./.github/workflows/nx-cloud-main.yml
     with:
       working-directory: ./integration-tests/npm
-      install-command: |
-        echo "Installing dependencies with custom install-command"
+      install-commands: |
+        echo "Installing dependencies with custom install-commands"
         npm ci
         touch ./install-command-success
         echo "install command end"
@@ -49,3 +49,8 @@ jobs:
     with:
       working-directory: ./integration-tests/npm
       number-of-agents: 3
+      install-commands: |
+        echo "Installing dependencies with custom install-commands"
+        npm ci
+        touch ./install-command-success
+        echo "install command end"

--- a/.github/workflows/nx-cloud-agents.yml
+++ b/.github/workflows/nx-cloud-agents.yml
@@ -124,12 +124,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-yarn-
 
-      - name: Install dependencies
+      - name: Run any configured install-command
+        if: ${{ inputs.install-command != '' }}
         run: |
-          if [ -n "${{ inputs.install-command }}" ]; then
-            echo "Running custom install-command: ${{ inputs.install-command }}"
-            ${{ inputs.install-command }}
-          elif [ "${{ steps.package_manager.outputs.name == 'yarn' }}" == "true" ]; then
+          ${{ inputs.install-command }}
+      - name: Install dependencies
+        if: ${{ inputs.install-command == '' }}
+        run: |
+          if [ "${{ steps.package_manager.outputs.name == 'yarn' }}" == "true" ]; then
             echo "Running yarn install --frozen-lockfile"
             yarn install --frozen-lockfile
           elif [ "${{ steps.package_manager.outputs.name == 'pnpm' }}" == "true" ]; then

--- a/.github/workflows/nx-cloud-agents.yml
+++ b/.github/workflows/nx-cloud-agents.yml
@@ -18,7 +18,7 @@ on:
       pnpm-version:
         required: false
         type: string
-      install-command:
+      install-commands:
         required: false
         type: string
       # We needed this input in order to be able to configure out integration tests for this repo, it is not documented
@@ -124,12 +124,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-yarn-
 
-      - name: Run any configured install-command
-        if: ${{ inputs.install-command != '' }}
+      - name: Run any configured install-commands
+        if: ${{ inputs.install-commands != '' }}
         run: |
-          ${{ inputs.install-command }}
+          ${{ inputs.install-commands }}
       - name: Install dependencies
-        if: ${{ inputs.install-command == '' }}
+        if: ${{ inputs.install-commands == '' }}
         run: |
           if [ "${{ steps.package_manager.outputs.name == 'yarn' }}" == "true" ]; then
             echo "Running yarn install --frozen-lockfile"

--- a/.github/workflows/nx-cloud-main.yml
+++ b/.github/workflows/nx-cloud-main.yml
@@ -140,12 +140,14 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-yarn-
 
-      - name: Install dependencies
+      - name: Run any configured install-command
+        if: ${{ inputs.install-command != '' }}
         run: |
-          if [ -n "${{ inputs.install-command }}" ]; then
-            echo "Running custom install-command: ${{ inputs.install-command }}"
-            ${{ inputs.install-command }}
-          elif [ "${{ steps.package_manager.outputs.name == 'yarn' }}" == "true" ]; then
+          ${{ inputs.install-command }}
+      - name: Install dependencies
+        if: ${{ inputs.install-command == '' }}
+        run: |
+          if [ "${{ steps.package_manager.outputs.name == 'yarn' }}" == "true" ]; then
             echo "Running yarn install --frozen-lockfile"
             yarn install --frozen-lockfile
           elif [ "${{ steps.package_manager.outputs.name == 'pnpm' }}" == "true" ]; then

--- a/.github/workflows/nx-cloud-main.yml
+++ b/.github/workflows/nx-cloud-main.yml
@@ -27,7 +27,7 @@ on:
       pnpm-version:
         required: false
         type: string
-      install-command:
+      install-commands:
         required: false
         type: string
       main-branch-name:
@@ -140,12 +140,12 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-yarn-
 
-      - name: Run any configured install-command
-        if: ${{ inputs.install-command != '' }}
+      - name: Run any configured install-commands
+        if: ${{ inputs.install-commands != '' }}
         run: |
-          ${{ inputs.install-command }}
+          ${{ inputs.install-commands }}
       - name: Install dependencies
-        if: ${{ inputs.install-command == '' }}
+        if: ${{ inputs.install-commands == '' }}
         run: |
           if [ "${{ steps.package_manager.outputs.name == 'yarn' }}" == "true" ]; then
             echo "Running yarn install --frozen-lockfile"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p style="text-align: center;"><img src=".github/assets/nx.png" 
 width="100%" alt="Nx - Smart, Extensible Build Framework"></p>
 
-<h1 align="center">Nx Cloud Github Workflows</h2>
+<h1 align="center">Nx Cloud Github Workflows</h1>
 
 ✨ Github Workflows for easily configuring distributed CI pipelines powered by the speed and intelligence of Nx Cloud.
 
@@ -30,8 +30,8 @@ The following will configure a CI workflow which runs on the `main` branch, and 
 - Checkout your repo at the appropriate depth for determining affected projects
 - Determine the `head` and `base` SHAs to use for `nx affected`
 - Install nodejs
-- Use an appropriate node_module caching strategy for either `yarn` or `npm` (depending on which one is configured in your repo)
-- Install dependencies with either `yarn` or `npm` (depending on which one is configured in your repo)
+- Use an appropriate node_module caching strategy for either `yarn`, `npm` or `pnpm` (depending on which one is configured in your repo)
+- Install locked dependencies with either `yarn`, `npm` or `pnpm` (depending on which one is configured in your repo)
 - Spawn 3 agents ready to receive tasks/targets to run
 - Initiate all the provided commands in parallel, with those defined in `parallel-commands` being executed on the main job, and those in `parallel-commands-on-agents` being intelligently distributed across the 3 agents by Nx Cloud
 - Shut down all agents when all parallel tasks have completed
@@ -140,8 +140,7 @@ jobs:
     pnpm-version: ""
 
     # [OPTIONAL] If you want to provide specific install commands to use when installing dependencies
-    # you can do that here. If you do not specify one, it will check for the configured package manager
-    # (yarn, pnpm, or npm are currenctly supported) and run `npm ci` or `yarn install --frozen-lockfile`.
+    # you can do that here. The default install step is not executed when this input is given.
     install-commands: ""
 ```
 
@@ -180,8 +179,7 @@ jobs:
     pnpm-version: ""
 
     # [OPTIONAL] If you want to provide specific install commands to use when installing dependencies
-    # you can do that here. If you do not specify one, it will check for the configured package manager
-    # (yarn, pnpm, or npm are currenctly supported) and run `npm ci` or `yarn install --frozen-lockfile`.
+    # you can do that here. The default install step is not executed when this input is given.
     install-commands: ""
 ```
 

--- a/README.md
+++ b/README.md
@@ -139,11 +139,10 @@ jobs:
     # Pnpm gets installed only if pnpm-lock.yaml is present in your repo.
     pnpm-version: ""
 
-    # [OPTIONAL] If you want to provide a specific install command to use when installing dependencies
-    # you can do that here. If you do not specify one, it will check for the presence of a yarn.lock
-    # file in your repo, and if it finds one, run `yarn install --frozen-lockfile`. Otherwise it will
-    # run `npm ci`.
-    install-command: ""
+    # [OPTIONAL] If you want to provide specific install commands to use when installing dependencies
+    # you can do that here. If you do not specify one, it will check for the configured package manager
+    # (yarn, pnpm, or npm are currenctly supported) and run `npm ci` or `yarn install --frozen-lockfile`.
+    install-commands: ""
 ```
 
 <!-- end configuration-options-for-the-main-job -->
@@ -180,11 +179,10 @@ jobs:
     # Pnpm gets installed only if pnpm-lock.yaml is present in your repo.
     pnpm-version: ""
 
-    # [OPTIONAL] If you want to provide a specific install command to use when installing dependencies
-    # you can do that here. If you do not specify one, it will check for the presence of a yarn.lock
-    # file in your repo, and if it finds one, run `yarn install --frozen-lockfile`. Otherwise it will
-    # run `npm ci`.
-    install-command: ""
+    # [OPTIONAL] If you want to provide specific install commands to use when installing dependencies
+    # you can do that here. If you do not specify one, it will check for the configured package manager
+    # (yarn, pnpm, or npm are currenctly supported) and run `npm ci` or `yarn install --frozen-lockfile`.
+    install-commands: ""
 ```
 
 <!-- end configuration-options-for-agent-jobs -->

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "private": true,
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "This package.json is here purely to control the version of the Action, in combination with https://github.com/JamesHenry/publish-shell-action"
 }


### PR DESCRIPTION
- add missing `echo` command to fix the detection of package-manger for npm
- fix install-command does not work if the install-command contains apostrophe

Fixes #10 