### PR TITLE
feat(main): add NX_CLOUD_DISTRIBUTED_EXECUTION_AGENT_COUNT support

### DIFF
--- a/.github/workflows/nx-cloud-main.yml
+++ b/.github/workflows/nx-cloud-main.yml
@@ -45,7 +45,7 @@ on:
 
 env:
   NX_CLOUD_DISTRIBUTED_EXECUTION: true
-  NX_CLOUD_DISTRIBUTED_EXECUTION_AGENT_COUNT: ${{ inputs.number-of-agents || 6 }}
+  NX_CLOUD_DISTRIBUTED_EXECUTION_AGENT_COUNT: ${{ inputs.number-of-agents }}
   NX_BRANCH: ${{ github.event.number || github.ref_name }}
 
 jobs:

--- a/.github/workflows/nx-cloud-main.yml
+++ b/.github/workflows/nx-cloud-main.yml
@@ -3,6 +3,9 @@ name: Nx Cloud Main
 on:
   workflow_call:
     inputs:
+      number-of-agents:
+        required: false
+        type: number
       init-commands:
         required: false
         type: string
@@ -42,6 +45,7 @@ on:
 
 env:
   NX_CLOUD_DISTRIBUTED_EXECUTION: true
+  NX_CLOUD_DISTRIBUTED_EXECUTION_AGENT_COUNT: ${{ inputs.number-of-agents || 6 }}
   NX_BRANCH: ${{ github.event.number || github.ref_name }}
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -82,8 +82,12 @@ jobs:
 ```yaml
 - uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.3
   with:
-    # [OPTIONAL] The available number of agents used for fine tuning
-    # the Nx Cloud to intelligently distribute tasks in parallel.
+    # [OPTIONAL] The available number of agents used by the Nx Cloud to distribute tasks in parallel.
+    # By default, NxCloud tries to infer dynamically how many agents you have available. Some agents 
+    # can have delayed start leading to incorrect count when distributing tasks.
+    #
+    # If you know exactly how many agents you have available, it is recommended to set this so we can more 
+    # reliably distribute the tasks.
     number-of-agents: 3
 
     # [OPTIONAL] A multi-line string representing any bash commands (separated by new lines) which should

--- a/README.md
+++ b/README.md
@@ -84,8 +84,6 @@ jobs:
   with:
     # [OPTIONAL] The available number of agents used for fine tuning
     # the Nx Cloud to intelligently distribute tasks in parallel.
-    #
-    # Default: 6
     number-of-agents: 3
 
     # [OPTIONAL] A multi-line string representing any bash commands (separated by new lines) which should

--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ jobs:
 ```yaml
 - uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.3
   with:
+    # [OPTIONAL] The available number of agents use to fine tune
+    # Nx Cloud to intelligently distribute tasks in parallel.
+    #
+    # Default: 6
+    number-of-agents: 3
+
     # [OPTIONAL] A multi-line string representing any bash commands (separated by new lines) which should
     # run sequentially, directly on the main job BEFORE executing any of the parallel commands which
     # may be specified via parallel-commands and/or parallel-commands-on-agents

--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ jobs:
 ```yaml
 - uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.3
   with:
-    # [OPTIONAL] The available number of agents use to fine tune
-    # Nx Cloud to intelligently distribute tasks in parallel.
+    # [OPTIONAL] The available number of agents used for fine tuning
+    # the Nx Cloud to intelligently distribute tasks in parallel.
     #
     # Default: 6
     number-of-agents: 3

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "private": true,
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "This package.json is here purely to control the version of the Action, in combination with https://github.com/JamesHenry/publish-shell-action"
 }


### PR DESCRIPTION
This feature has been requested by our enterprise clients, for whom setting the NX_CLOUD_DISTRIBUTED_EXECUTION_AGENT_COUNT greatly impacts the optimal distribution of work across all available agents.

**Additional information**

(information gathered from @rarmatei and @StalkAltan)

## Why is NX_CLOUD_DISTRIBUTED_EXECUTION_AGENT_COUNT needed?

Due to the asynchronous nature of jobs, it often happens that the main job's `nx` steps start before all the agents have been created or started. This causes DTE to operate with incomplete information about the number of available agents and produce a sub-optimal distribution of tasks. Although it doesn't make much difference on smaller projects or projects with a smaller (<10) number of agents, specifying this environment variable on projects with a large number of agents (e.g. 50) can have noticeable time savings.

## Why default to 6 and not 3?

The default value for `NX_CLOUD_DISTRIBUTED_EXECUTION_AGENT_COUNT` on Nx-Cloud is 6, so setting it to 6 is equivalent to not having it set at all.

## Why 6?

This is the result of the statistics done on Nx Cloud, where 6 gave the best results when "guessing" the number of available agents. Perhaps @vsavkin can provide more background to it.