### PR TITLE
fix: agent jobs read access tokens the same way as main job

### DIFF
--- a/.github/workflows/nx-cloud-agents.yml
+++ b/.github/workflows/nx-cloud-agents.yml
@@ -2,6 +2,11 @@ name: Nx Cloud Agents
 
 on:
   workflow_call:
+    secrets:
+      NX_CLOUD_ACCESS_TOKEN:
+        required: false
+      NX_CLOUD_AUTH_TOKEN:
+        required: false
     inputs:
       number-of-agents:
         required: true
@@ -36,6 +41,9 @@ on:
 
 env:
   NX_CLOUD_DISTRIBUTED_EXECUTION: true
+  NX_BRANCH: ${{ github.event.number || github.ref_name }}
+  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+  NX_CLOUD_AUTH_TOKEN: ${{ secrets.NX_CLOUD_AUTH_TOKEN }}
 
 jobs:
   set-agents:

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ jobs:
 
 ## Adding read-write Nx Cloud access token to workflow
 
-The main workflow supports passing `NX_CLOUD_AUTH_TOKEN` and `NX_CLOUD_ACCESS_TOKEN` from the parent workflow.
+The main and agent workflows both support passing `NX_CLOUD_AUTH_TOKEN` and `NX_CLOUD_ACCESS_TOKEN` from the parent workflow.
 This is accomplished by adding `secrets: inherit` which gives access to the secrets of the parent.
 These secrets are still kept encrypted and the `main` workflow will only use the `NX_CLOUD_AUTH_TOKEN` and `NX_CLOUD_ACCESS_TOKEN` 
 if those are defined.
@@ -111,6 +111,7 @@ jobs:
   agents:
     name: Nx Cloud - Agents
     uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.6
+    secrets: inherit
     with:
       ...
 ```

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "private": true,
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "This package.json is here purely to control the version of the Action, in combination with https://github.com/JamesHenry/publish-shell-action"
 }


### PR DESCRIPTION
The `nx-cloud-agents` workflow was not setting an env var for either `NX_CLOUD_ACCESS_TOKEN` or `NX_CLOUD_AUTH_TOKEN`. This can break DTE in cases where a user has a read-only token committed, but provides a read-write token through Github Secrets.

Also added `NX_BRANCH` so the main/agent jobs are in sync there as well.