### PR TITLE
chore: update actions to the `node16` runtime

### DIFF
--- a/.github/workflows/nx-cloud-agents.yml
+++ b/.github/workflows/nx-cloud-agents.yml
@@ -75,7 +75,7 @@ jobs:
         # Specify shell to help normalize across different operating systems
         shell: bash
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Detect package manager
         id: package_manager
@@ -112,7 +112,7 @@ jobs:
 
       - name: Use the node_modules cache if available [npm]
         if: steps.package_manager.outputs.name == 'npm'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-${{ hashFiles('**/package-lock.json') }}
@@ -121,7 +121,7 @@ jobs:
 
       - name: Use the node_modules cache if available [pnpm]
         if: steps.package_manager.outputs.name == 'pnpm'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -135,7 +135,7 @@ jobs:
 
       - name: Use the node_modules cache if available [yarn]
         if: steps.package_manager.outputs.name == 'yarn'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/nx-cloud-agents.yml
+++ b/.github/workflows/nx-cloud-agents.yml
@@ -92,7 +92,7 @@ jobs:
       # Install pnpm with exact version provided by consumer or fallback to latest
       - name: Install PNPM
         if: steps.package_manager.outputs.name == 'pnpm'
-        uses: pnpm/action-setup@v2.2.1
+        uses: pnpm/action-setup@v2.2.2
         with:
           version: ${{ inputs.pnpm-version || 'latest' }}
 

--- a/.github/workflows/nx-cloud-agents.yml
+++ b/.github/workflows/nx-cloud-agents.yml
@@ -83,7 +83,7 @@ jobs:
           echo "::set-output name=name::$([[ -f ./yarn.lock ]] && echo "yarn" || ([[ -f ./pnpm-lock.yaml ]] && echo "pnpm") || echo "npm")"
 
       # Set node/npm/yarn versions using volta, with optional overrides provided by the consumer
-      - uses: volta-cli/action@fdf4cf319494429a105efaa71d0e5ec67f338c6e
+      - uses: volta-cli/action@v4
         with:
           node-version: "${{ inputs.node-version }}"
           npm-version: "${{ inputs.npm-version }}"

--- a/.github/workflows/nx-cloud-main.yml
+++ b/.github/workflows/nx-cloud-main.yml
@@ -74,7 +74,7 @@ jobs:
         # Specify shell to help normalize across different operating systems
         shell: bash
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout [Pull Request]
         if: ${{ github.event_name == 'pull_request' }}
         with:
@@ -83,7 +83,7 @@ jobs:
           # We need to fetch all branches and commits so that Nx affected has a base to compare against.
           fetch-depth: 0
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         name: Checkout [Default Branch]
         if: ${{ github.event_name != 'pull_request' }}
         with:
@@ -131,7 +131,7 @@ jobs:
 
       - name: Use the node_modules cache if available [npm]
         if: steps.package_manager.outputs.name == 'npm'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-${{ hashFiles('**/package-lock.json') }}
@@ -140,7 +140,7 @@ jobs:
 
       - name: Use the node_modules cache if available [pnpm]
         if: steps.package_manager.outputs.name == 'pnpm'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -154,7 +154,7 @@ jobs:
 
       - name: Use the node_modules cache if available [yarn]
         if: steps.package_manager.outputs.name == 'yarn'
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/nx-cloud-main.yml
+++ b/.github/workflows/nx-cloud-main.yml
@@ -111,7 +111,7 @@ jobs:
       # Install pnpm with exact version provided by consumer or fallback to latest
       - name: Install PNPM
         if: steps.package_manager.outputs.name == 'pnpm'
-        uses: pnpm/action-setup@v2.2.1
+        uses: pnpm/action-setup@v2.2.2
         with:
           version: ${{ inputs.pnpm-version || 'latest' }}
 

--- a/.github/workflows/nx-cloud-main.yml
+++ b/.github/workflows/nx-cloud-main.yml
@@ -102,7 +102,7 @@ jobs:
           echo "::set-output name=name::$([[ -f ./yarn.lock ]] && echo "yarn" || ([[ -f ./pnpm-lock.yaml ]] && echo "pnpm") || echo "npm")"
 
       # Set node/npm/yarn versions using volta, with optional overrides provided by the consumer
-      - uses: volta-cli/action@fdf4cf319494429a105efaa71d0e5ec67f338c6e
+      - uses: volta-cli/action@v4
         with:
           node-version: "${{ inputs.node-version }}"
           npm-version: "${{ inputs.npm-version }}"

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ concurrency:
 jobs:
   main:
     name: Nx Cloud - Main Job
-    uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.7
+    uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.8
     with:
       parallel-commands: |
         npx nx workspace-lint
@@ -68,7 +68,7 @@ jobs:
 
   agents:
     name: Nx Cloud - Agents
-    uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.7
+    uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.8
     with:
       number-of-agents: 3
 ```
@@ -79,9 +79,8 @@ jobs:
 
 The main and agent workflows both support passing `NX_CLOUD_AUTH_TOKEN` and `NX_CLOUD_ACCESS_TOKEN` from the parent workflow.
 This is accomplished by adding `secrets: inherit` which gives access to the secrets of the parent.
-These secrets are still kept encrypted and the `main` workflow will only use the `NX_CLOUD_AUTH_TOKEN` and `NX_CLOUD_ACCESS_TOKEN` 
+These secrets are still kept encrypted and the `main` workflow will only use the `NX_CLOUD_AUTH_TOKEN` and `NX_CLOUD_ACCESS_TOKEN`
 if those are defined.
-
 
 **.github/workflows/ci.yml**
 
@@ -103,17 +102,15 @@ concurrency:
 jobs:
   main:
     name: Nx Cloud - Main Job
-    uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.7
+    uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.8
     secrets: inherit
-    with:
-      ...
+    with: ...
 
   agents:
     name: Nx Cloud - Agents
-    uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.7
+    uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.8
     secrets: inherit
-    with:
-      ...
+    with: ...
 ```
 
 <!-- end example-usage -->
@@ -123,13 +120,13 @@ jobs:
 <!-- start configuration-options-for-the-main-job -->
 
 ```yaml
-- uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.7
+- uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.8
   with:
     # [OPTIONAL] The available number of agents used by the Nx Cloud to distribute tasks in parallel.
-    # By default, NxCloud tries to infer dynamically how many agents you have available. Some agents 
+    # By default, NxCloud tries to infer dynamically how many agents you have available. Some agents
     # can have delayed start leading to incorrect count when distributing tasks.
     #
-    # If you know exactly how many agents you have available, it is recommended to set this so we can more 
+    # If you know exactly how many agents you have available, it is recommended to set this so we can more
     # reliably distribute the tasks.
     number-of-agents: 3
 
@@ -201,10 +198,10 @@ jobs:
     # [OPTIONAL] If you want to provide specific install commands to use when installing dependencies
     # you can do that here. The default install step is not executed when this input is given.
     install-commands: ""
-    
+
     # [OPTIONAL] Provides override for type of the machine to run the workflow on
     # The machine can be either a GitHub-hosted runner or a self-hosted runner
-    # 
+    #
     # NOTE: If you change this option, make sure it matches the agent configuration
     # Default: ubuntu-latest
     runs-on: ""
@@ -217,7 +214,7 @@ jobs:
 <!-- start configuration-options-for-agent-jobs -->
 
 ```yaml
-- uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.7
+- uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.8
   with:
     # [REQUIRED] The number of agents which should be created as part of the workflow in order to
     # allow Nx Cloud to intelligently distribute tasks in parallel.
@@ -226,7 +223,7 @@ jobs:
     # [OPTIONAL] A multi-line string containing non-secret environment variables which need to be passed from the parent workflow
     # to the reusable workflow. The variables are defined in form `VARIABLE_NAME=value`
     #
-    # NOTE: Environment variables cannot contain values derived from ${{ secrets }} 
+    # NOTE: Environment variables cannot contain values derived from ${{ secrets }}
     # because of how reusable workflows work
     environment-variables: |
       ""
@@ -258,7 +255,7 @@ jobs:
 
     # [OPTIONAL] Provides override for type of the machine to run the workflow on
     # The machine can be either a GitHub-hosted runner or a self-hosted runner
-    # 
+    #
     # NOTE: If you change this option, make sure it matches the main configuration
     # Default: ubuntu-latest
     runs-on: ""

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "private": true,
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "This package.json is here purely to control the version of the Action, in combination with https://github.com/JamesHenry/publish-shell-action"
 }


### PR DESCRIPTION
Update 2nd and 3rd party actions to versions using the `node16` runtime.

This fixes the following error message shown when using the reusable DTE workflows:
> Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: actions/checkout, volta-cli/action, actions/cache, actions/cache, actions/checkout

This must be done by Summer 2023, or actions stuck on the `node16` runtime will break.

Other than the switch to `node16`, the `volta-cli/action` has a breaking change worth considering whether it should force a breaking change in our reusable workflows:
> Break Volta <1.0.0 compatibility.

However, we are currently using prerelease versions, so any 0.x version increment has breaking changes according to semantic versioning. Thus, I have bumped the version from 0.6.0 to 0.7.0 to err on the side of caution.