### PR TITLE
Update volta-cli action version

### DIFF
--- a/.github/workflows/nx-cloud-agents.yml
+++ b/.github/workflows/nx-cloud-agents.yml
@@ -83,7 +83,7 @@ jobs:
           echo "::set-output name=name::$([[ -f ./yarn.lock ]] && echo "yarn" || ([[ -f ./pnpm-lock.yaml ]] && echo "pnpm") || echo "npm")"
 
       # Set node/npm/yarn versions using volta, with optional overrides provided by the consumer
-      - uses: volta-cli/action@fdf4cf319494429a105efaa71d0e5ec67f338c6e
+      - uses: volta-cli/action@v4
         with:
           node-version: "${{ inputs.node-version }}"
           npm-version: "${{ inputs.npm-version }}"

--- a/.github/workflows/nx-cloud-main.yml
+++ b/.github/workflows/nx-cloud-main.yml
@@ -102,7 +102,7 @@ jobs:
           echo "::set-output name=name::$([[ -f ./yarn.lock ]] && echo "yarn" || ([[ -f ./pnpm-lock.yaml ]] && echo "pnpm") || echo "npm")"
 
       # Set node/npm/yarn versions using volta, with optional overrides provided by the consumer
-      - uses: volta-cli/action@fdf4cf319494429a105efaa71d0e5ec67f338c6e
+      - uses: volta-cli/action@v4
         with:
           node-version: "${{ inputs.node-version }}"
           npm-version: "${{ inputs.npm-version }}"


### PR DESCRIPTION
Related to https://github.com/volta-cli/action/issues/117

Nx-cloud workflows have suddenly stopped running due to the volta-cli action returning a 404.

```
Run volta-cli/action@fdf4cf319494429a105efaa71d0e5ec67f338c6e
  with:
    always-auth: false
  env:
    NX_CLOUD_DISTRIBUTED_EXECUTION: true
    NX_CLOUD_DISTRIBUTED_EXECUTION_AGENT_COUNT: 3
    NX_BRANCH: 60
    NX_CLOUD_ACCESS_TOKEN: 
    NX_CLOUD_AUTH_TOKEN: 
    NX_BASE: 7b2b98e84759aa72f6ac957ac2ede241f23f2933
    NX_HEAD: def864e75fe7e1449fba11ba1e6a27e22f35a2d7
downloading volta@1.1.0
Error: Unexpected HTTP response: 404
```