### PR TITLE
refactor: migrate internal output parameters

### DIFF
--- a/.github/workflows/nx-cloud-agents.yml
+++ b/.github/workflows/nx-cloud-agents.yml
@@ -58,7 +58,7 @@ jobs:
         run: |
           AGENTS_JSON_ARRAY=$(node -e "console.log(JSON.stringify(Array.from(new Array(${{ inputs.number-of-agents }})).map((_, i) => i + 1)));")
           echo $AGENTS_JSON_ARRAY
-          echo "::set-output name=matrix::$AGENTS_JSON_ARRAY"
+          echo "matrix=$AGENTS_JSON_ARRAY" >> $GITHUB_OUTPUT
 
   # Intentionally using capital letter in order to make the Github UI for the matrix look better
   Run:
@@ -80,7 +80,7 @@ jobs:
       - name: Detect package manager
         id: package_manager
         run: |
-          echo "::set-output name=name::$([[ -f ./yarn.lock ]] && echo "yarn" || ([[ -f ./pnpm-lock.yaml ]] && echo "pnpm") || echo "npm")"
+          echo "name=$([[ -f ./yarn.lock ]] && echo "yarn" || ([[ -f ./pnpm-lock.yaml ]] && echo "pnpm") || echo "npm")" >> $GITHUB_OUTPUT
 
       # Set node/npm/yarn versions using volta, with optional overrides provided by the consumer
       - uses: volta-cli/action@v4
@@ -108,7 +108,7 @@ jobs:
           if [[ $yarn_ver != '' ]]; then echo "Yarn: $yarn_ver"; fi
           if [[ $pnpm_ver != '' ]]; then echo "PNPM: $pnpm_ver"; fi
 
-          echo "::set-output name=node_version::${node_ver:1}"
+          echo "node_version=${node_ver:1}" >> $GITHUB_OUTPUT
 
       - name: Use the node_modules cache if available [npm]
         if: steps.package_manager.outputs.name == 'npm'
@@ -131,7 +131,7 @@ jobs:
       - name: Get yarn cache directory path
         if: steps.package_manager.outputs.name == 'yarn'
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Use the node_modules cache if available [yarn]
         if: steps.package_manager.outputs.name == 'yarn'

--- a/.github/workflows/nx-cloud-main.yml
+++ b/.github/workflows/nx-cloud-main.yml
@@ -99,7 +99,7 @@ jobs:
         id: package_manager
         shell: bash
         run: |
-          echo "::set-output name=name::$([[ -f ./yarn.lock ]] && echo "yarn" || ([[ -f ./pnpm-lock.yaml ]] && echo "pnpm") || echo "npm")"
+          echo "name=$([[ -f ./yarn.lock ]] && echo "yarn" || ([[ -f ./pnpm-lock.yaml ]] && echo "pnpm") || echo "npm")" >> $GITHUB_OUTPUT
 
       # Set node/npm/yarn versions using volta, with optional overrides provided by the consumer
       - uses: volta-cli/action@v4
@@ -127,7 +127,7 @@ jobs:
           if [[ $yarn_ver != '' ]]; then echo "Yarn: $yarn_ver"; fi
           if [[ $pnpm_ver != '' ]]; then echo "PNPM: $pnpm_ver"; fi
 
-          echo "::set-output name=node_version::${node_ver:1}"
+          echo "node_version=${node_ver:1}" >> $GITHUB_OUTPUT
 
       - name: Use the node_modules cache if available [npm]
         if: steps.package_manager.outputs.name == 'npm'
@@ -150,7 +150,7 @@ jobs:
       - name: Get yarn cache directory path
         if: steps.package_manager.outputs.name == 'yarn'
         id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
+        run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
 
       - name: Use the node_modules cache if available [yarn]
         if: steps.package_manager.outputs.name == 'yarn'

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "private": true,
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "This package.json is here purely to control the version of the Action, in combination with https://github.com/JamesHenry/publish-shell-action"
 }


### PR DESCRIPTION
`::set-output` is deprecated. Environment files, in this case `GITHUB_OUTPUT` must be used instead as described at https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.

This migration must happen before May 31st, 2023.

Fixes the following warning.
> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
