### PR TITLE
feat: support NPM_TOKEN secret

### DIFF
--- a/.github/workflows/ci-integration-test-environment-variables-windows.yml
+++ b/.github/workflows/ci-integration-test-environment-variables-windows.yml
@@ -14,6 +14,11 @@ jobs:
   main:
     name: Nx Cloud - Main Job
     uses: ./.github/workflows/nx-cloud-main.yml
+    secrets:
+      NPM_TOKEN: ${{ secrets.SECRET_FOR_INTEGRATION_TEST }}
+      # NOTE: We cannot include these secrets in the integration tests otherwise they will interfere with the real connection to Nx Cloud
+      # NX_CLOUD_ACCESS_TOKEN: ${{ secrets.SECRET_FOR_INTEGRATION_TEST }}
+      # NX_CLOUD_AUTH_TOKEN: ${{ secrets.SECRET_FOR_INTEGRATION_TEST }}
     with:
       runs-on: windows-latest
       working-directory: ./integration-tests/npm
@@ -27,11 +32,13 @@ jobs:
         node -e "if(process.env.MY_BOOLEAN == 'true') console.log('Boolean parsing successful'); else { throw new Error('Boolean parsing failed!');}"
         node -e "if(process.env.CAPITAL_BOOLEAN == 'false') console.log('Capital boolean parsing successful'); else { throw new Error('Capital boolean parsing failed!');}"
         node -e "if(process.env.OTHER_TEXT == 'some other \\"text\\"') console.log('Text parsing successful'); else { throw new Error('Text parsing failed!');}"
+        node -e "if(process.env.NPM_TOKEN == 'SOME_NOT_SO_SECRET_VALUE') console.log('NPM_TOKEN secret parsing successful'); else { throw new Error('NPM_TOKEN secret parsing failed!');}"
       parallel-commands-on-agents: |
         node -e "if(process.env.SOME_NUMBER == 42) console.log('Number parsing on agent successful'); else { throw new Error('Number parsing on agent failed!');}"
         node -e "if(process.env.MY_BOOLEAN == 'true') console.log('Boolean parsing on agent successful'); else { throw new Error('Boolean parsing on agent failed!');}"
         node -e "if(process.env.CAPITAL_BOOLEAN == 'false') console.log('Capital boolean parsing on agent successful'); else { throw new Error('Capital boolean parsing on agent failed!');}"
         node -e "if(process.env.OTHER_TEXT == 'some other \\"text\\"') console.log('Text parsing on agent successful'); else { throw new Error('Text parsing on agent failed!');}"
+        node -e "if(process.env.NPM_TOKEN == 'SOME_NOT_SO_SECRET_VALUE') console.log('NPM_TOKEN secret parsing successful'); else { throw new Error('NPM_TOKEN secret parsing failed!');}"
 
   agents:
     name: Nx Cloud - Agents

--- a/.github/workflows/ci-integration-test-environment-variables.yml
+++ b/.github/workflows/ci-integration-test-environment-variables.yml
@@ -14,6 +14,11 @@ jobs:
   main:
     name: Nx Cloud - Main Job
     uses: ./.github/workflows/nx-cloud-main.yml
+    secrets:
+      NPM_TOKEN: ${{ secrets.SECRET_FOR_INTEGRATION_TEST }}
+      # NOTE: We cannot include these secrets in the integration tests otherwise they will interfere with the real connection to Nx Cloud
+      # NX_CLOUD_ACCESS_TOKEN: ${{ secrets.SECRET_FOR_INTEGRATION_TEST }}
+      # NX_CLOUD_AUTH_TOKEN: ${{ secrets.SECRET_FOR_INTEGRATION_TEST }}
     with:
       working-directory: ./integration-tests/npm
       environment-variables: |
@@ -26,11 +31,13 @@ jobs:
         node -e "if(process.env.MY_BOOLEAN == 'true') console.log('Boolean parsing successful'); else { throw new Error('Boolean parsing failed!');}"
         node -e "if(process.env.CAPITAL_BOOLEAN == 'false') console.log('Capital boolean parsing successful'); else { throw new Error('Capital boolean parsing failed!');}"
         node -e "if(process.env.OTHER_TEXT == 'some other \\"text\\"') console.log('Text parsing successful'); else { throw new Error('Text parsing failed!');}"
+        node -e "if(process.env.NPM_TOKEN == 'SOME_NOT_SO_SECRET_VALUE') console.log('NPM_TOKEN secret parsing successful'); else { throw new Error('NPM_TOKEN secret parsing failed!');}"
       parallel-commands-on-agents: |
         node -e "if(process.env.SOME_NUMBER == 42) console.log('Number parsing on agent successful'); else { throw new Error('Number parsing on agent failed!');}"
         node -e "if(process.env.MY_BOOLEAN == 'true') console.log('Boolean parsing on agent successful'); else { throw new Error('Boolean parsing on agent failed!');}"
         node -e "if(process.env.CAPITAL_BOOLEAN == 'false') console.log('Capital boolean parsing on agent successful'); else { throw new Error('Capital boolean parsing on agent failed!');}"
         node -e "if(process.env.OTHER_TEXT == 'some other \\"text\\"') console.log('Text parsing on agent successful'); else { throw new Error('Text parsing on agent failed!');}"
+        node -e "if(process.env.NPM_TOKEN == 'SOME_NOT_SO_SECRET_VALUE') console.log('NPM_TOKEN secret parsing successful'); else { throw new Error('NPM_TOKEN secret parsing failed!');}"
 
   agents:
     name: Nx Cloud - Agents

--- a/.github/workflows/nx-cloud-agents.yml
+++ b/.github/workflows/nx-cloud-agents.yml
@@ -3,6 +3,8 @@ name: Nx Cloud Agents
 on:
   workflow_call:
     secrets:
+      NPM_TOKEN:
+        required: false
       NX_CLOUD_ACCESS_TOKEN:
         required: false
       NX_CLOUD_AUTH_TOKEN:
@@ -44,6 +46,7 @@ env:
   NX_BRANCH: ${{ github.event.number || github.ref_name }}
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
   NX_CLOUD_AUTH_TOKEN: ${{ secrets.NX_CLOUD_AUTH_TOKEN }}
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
 jobs:
   set-agents:

--- a/.github/workflows/nx-cloud-main.yml
+++ b/.github/workflows/nx-cloud-main.yml
@@ -3,6 +3,8 @@ name: Nx Cloud Main
 on:
   workflow_call:
     secrets:
+      NPM_TOKEN:
+        required: false
       NX_CLOUD_ACCESS_TOKEN:
         required: false
       NX_CLOUD_AUTH_TOKEN:
@@ -69,6 +71,7 @@ env:
   NX_BRANCH: ${{ github.event.number || github.ref_name }}
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
   NX_CLOUD_AUTH_TOKEN: ${{ secrets.NX_CLOUD_AUTH_TOKEN }}
+  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
 jobs:
   main:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "private": true,
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "This package.json is here purely to control the version of the Action, in combination with https://github.com/JamesHenry/publish-shell-action"
 }


### PR DESCRIPTION
In addition to explicitly supporting the very common `NPM_TOKEN` secret, this PR:

- makes the limitations around secret handling much more prominent and clear
- adds some integration test coverage for secret passing

Closes #44 