### PR TITLE
fix: yarn version detection

### DIFF
--- a/.github/workflows/nx-cloud-main.yml
+++ b/.github/workflows/nx-cloud-main.yml
@@ -139,7 +139,7 @@ jobs:
           if [[ $pnpm_ver != '' ]]; then echo "PNPM: $pnpm_ver"; fi
 
           echo "node_version=${node_ver:1}" >> $GITHUB_OUTPUT
-          echo "yarn_version=${yarn_ver:1}" >> $GITHUB_OUTPUT
+          echo "yarn_version=${yarn_ver}" >> $GITHUB_OUTPUT
 
       - name: Use the node_modules cache if available [npm]
         if: steps.package_manager.outputs.name == 'npm'

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ concurrency:
 jobs:
   main:
     name: Nx Cloud - Main Job
-    uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.11
+    uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.11.1
     with:
       # NOTE: Here we are using the special `nx-cloud record` command to ensure that any commands we run that do not go through the cloud task runner natively
       # (i.e. anything that starts with `nx run`/`nx run-many`/`nx affected --target`), are still captured in the Nx Cloud UI and Github App comment for
@@ -75,7 +75,7 @@ jobs:
 
   agents:
     name: Nx Cloud - Agents
-    uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.11
+    uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.11.1
     with:
       number-of-agents: 3
 ```
@@ -110,7 +110,7 @@ concurrency:
 jobs:
   main:
     name: Nx Cloud - Main Job
-    uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.11
+    uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.11.1
     secrets:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
       NX_CLOUD_AUTH_TOKEN: ${{ secrets.NX_CLOUD_AUTH_TOKEN }}
@@ -118,7 +118,7 @@ jobs:
 
   agents:
     name: Nx Cloud - Agents
-    uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.11
+    uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.11.1
     secrets:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
       NX_CLOUD_AUTH_TOKEN: ${{ secrets.NX_CLOUD_AUTH_TOKEN }}
@@ -134,7 +134,7 @@ See the annotated configuration below for all explicitly supported secret values
 <!-- start configuration-options-for-the-main-job -->
 
 ```yaml
-- uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.11
+- uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.11.1
   # [OPTIONAL] Explicitly supported secret values which can be passed into the workflow from your outer workflow run.
   #
   # NOTE: You cannot access values from ${{ secrets }} beyond what is explicitly specified here because of the limitations of reusable Github workflows
@@ -249,7 +249,7 @@ See the annotated configuration below for all explicitly supported secret values
 <!-- start configuration-options-for-agent-jobs -->
 
 ```yaml
-- uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.11
+- uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.11.1
   # [OPTIONAL] Explicitly supported secret values which can be passed into the workflow from your outer workflow run.
   #
   # NOTE: You cannot access values from ${{ secrets }} beyond what is explicitly specified here because of the limitations of reusable Github workflows

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "private": true,
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "This package.json is here purely to control the version of the Action, in combination with https://github.com/JamesHenry/publish-shell-action"
 }


### PR DESCRIPTION
Because the Yarn version does not start with a `v` the first character should not be cut off. This is true for all major yarn versions:

```
$ yarn -v
1.22.19

$ yarn set version 2
2.4.3

$ yarn set version latest
3.3.0
```

Because of this the action currently falls back to yarn berry and this means that if you use yarn 1.x, caching does not work:
![yarn1](https://user-images.githubusercontent.com/6006/207536021-a9153f33-f254-4b74-ad7f-113fa87510d0.jpg)

I'm not sure how to write a test for this since the workflow works but only gives a warning in the last step.
