### PR TITLE
fix: lookup pnpm store path

### DIFF
--- a/.github/workflows/nx-cloud-agents.yml
+++ b/.github/workflows/nx-cloud-agents.yml
@@ -123,11 +123,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-
 
+      - name: Get pnpm cache directory path
+        if: steps.package_manager.outputs.name == 'pnpm'
+        id: pnpm-cache-dir-path
+        run: echo "dir=$(pnpm store path)" >> $GITHUB_OUTPUT
+
       - name: Use the node_modules cache if available [pnpm]
         if: steps.package_manager.outputs.name == 'pnpm'
         uses: actions/cache@v3
         with:
-          path: ~/.pnpm-store
+          path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-

--- a/.github/workflows/nx-cloud-main.yml
+++ b/.github/workflows/nx-cloud-main.yml
@@ -150,11 +150,16 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-
 
+      - name: Get pnpm cache directory path
+        if: steps.package_manager.outputs.name == 'pnpm'
+        id: pnpm-cache-dir-path
+        run: echo "dir=$(pnpm store path)" >> $GITHUB_OUTPUT
+
       - name: Use the node_modules cache if available [pnpm]
         if: steps.package_manager.outputs.name == 'pnpm'
         uses: actions/cache@v3
         with:
-          path: ~/.pnpm-store
+          path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
           restore-keys: |
             ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ concurrency:
 jobs:
   main:
     name: Nx Cloud - Main Job
-    uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.11.1
+    uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.11.2
     with:
       # NOTE: Here we are using the special `nx-cloud record` command to ensure that any commands we run that do not go through the cloud task runner natively
       # (i.e. anything that starts with `nx run`/`nx run-many`/`nx affected --target`), are still captured in the Nx Cloud UI and Github App comment for
@@ -75,7 +75,7 @@ jobs:
 
   agents:
     name: Nx Cloud - Agents
-    uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.11.1
+    uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.11.2
     with:
       number-of-agents: 3
 ```
@@ -110,7 +110,7 @@ concurrency:
 jobs:
   main:
     name: Nx Cloud - Main Job
-    uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.11.1
+    uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.11.2
     secrets:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
       NX_CLOUD_AUTH_TOKEN: ${{ secrets.NX_CLOUD_AUTH_TOKEN }}
@@ -118,7 +118,7 @@ jobs:
 
   agents:
     name: Nx Cloud - Agents
-    uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.11.1
+    uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.11.2
     secrets:
       NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
       NX_CLOUD_AUTH_TOKEN: ${{ secrets.NX_CLOUD_AUTH_TOKEN }}
@@ -134,7 +134,7 @@ See the annotated configuration below for all explicitly supported secret values
 <!-- start configuration-options-for-the-main-job -->
 
 ```yaml
-- uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.11.1
+- uses: nrwl/ci/.github/workflows/nx-cloud-main.yml@v0.11.2
   # [OPTIONAL] Explicitly supported secret values which can be passed into the workflow from your outer workflow run.
   #
   # NOTE: You cannot access values from ${{ secrets }} beyond what is explicitly specified here because of the limitations of reusable Github workflows
@@ -249,7 +249,7 @@ See the annotated configuration below for all explicitly supported secret values
 <!-- start configuration-options-for-agent-jobs -->
 
 ```yaml
-- uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.11.1
+- uses: nrwl/ci/.github/workflows/nx-cloud-agents.yml@v0.11.2
   # [OPTIONAL] Explicitly supported secret values which can be passed into the workflow from your outer workflow run.
   #
   # NOTE: You cannot access values from ${{ secrets }} beyond what is explicitly specified here because of the limitations of reusable Github workflows

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "private": true,
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "This package.json is here purely to control the version of the Action, in combination with https://github.com/JamesHenry/publish-shell-action"
 }


### PR DESCRIPTION
I noticed that the "Install dependencies" step did not reuse any packages.

Now using `pnpm store path` as input for the cache directory. 

Example output before:
![image](https://user-images.githubusercontent.com/6650168/208874983-f418bfb4-395f-4681-93e9-709a8b9262ad.png)

Example output after:
![image](https://user-images.githubusercontent.com/6650168/208875068-2bfffeab-6f9c-4af5-85fe-ee407da2fe96.png)
