### PR TITLE
feat: add timeout-minutes option to main jobs

### DIFF
--- a/.github/workflows/nx-cloud-agents.yml
+++ b/.github/workflows/nx-cloud-agents.yml
@@ -40,6 +40,9 @@ on:
       working-directory:
         required: false
         type: string
+      timeout-minutes:
+        required: false
+        type: number
 
 env:
   NX_CLOUD_DISTRIBUTED_EXECUTION: true
@@ -51,6 +54,7 @@ env:
 jobs:
   set-agents:
     runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes || 60 }}
     name: Init
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -67,6 +71,7 @@ jobs:
   Run:
     needs: set-agents
     runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes || 60 }}
     name: Agent ${{ matrix.agent }}
     strategy:
       matrix:

--- a/.github/workflows/nx-cloud-main.yml
+++ b/.github/workflows/nx-cloud-main.yml
@@ -64,6 +64,9 @@ on:
       working-directory:
         required: false
         type: string
+      timeout-minutes:
+        required: false
+        type: number
 
 env:
   NX_CLOUD_DISTRIBUTED_EXECUTION: true
@@ -76,6 +79,7 @@ env:
 jobs:
   main:
     runs-on: ${{ inputs.runs-on }}
+    timeout-minutes: ${{ inputs.timeout-minutes || 60 }}
     # The name of the job which will invoke this one is expected to be "Nx Cloud - Main Job", and whatever we call this will be appended
     # to that one after a forward slash, so we keep this one intentionally short to produce "Nx Cloud - Main Job / Run" in the Github UI
     name: Run


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Setting the `timeout-minutes` options for the main jobs is not enabled.

Fixes: #78 

## What is the new behavior?

Allows to specify the `timeout-minutes` option for the main jobs.

## Does this PR introduce a breaking change?

```
[x] Yes
[ ] No
```

It will set a default timeout of 60 minutes if no timeout is specified. This could affect pipelines that last more than 60 minutes.

In these cases, a greater `timeout-minutes` number must be specified.