### PR TITLE
docs: document working-directory

### DIFF
--- a/.github/workflows/nx-cloud-agents.yml
+++ b/.github/workflows/nx-cloud-agents.yml
@@ -35,8 +35,6 @@ on:
         required: false
         type: string
         default: ubuntu-latest
-      # We needed this input in order to be able to configure out integration tests for this repo, it is not documented
-      # so as to not cause confusion/add noise, but technically any consumer of the workflow can use it if they want to.
       working-directory:
         required: false
         type: string

--- a/.github/workflows/nx-cloud-main.yml
+++ b/.github/workflows/nx-cloud-main.yml
@@ -59,8 +59,6 @@ on:
         required: false
         type: string
         default: "nx-main-artifacts"
-      # We needed this input in order to be able to configure out integration tests for this repo, it is not documented
-      # so as to not cause confusion/add noise, but technically any consumer of the workflow can use it if they want to.
       working-directory:
         required: false
         type: string

--- a/README.md
+++ b/README.md
@@ -245,6 +245,10 @@ See the annotated configuration below for all explicitly supported secret values
     # NOTE: Timeout should be expressed in minutes
     # Default: 360
     timeout: ""
+
+    # [OPTIONAL] Provides override for repo's working directory
+    # Useful if root git repo contains multiple monorepos
+    working-directory: ""
 ```
 
 <!-- end configuration-options-for-the-main-job -->
@@ -312,6 +316,10 @@ See the annotated configuration below for all explicitly supported secret values
     # NOTE: Timeout should be expressed in minutes
     # Default: 360
     timeout: ""
+
+    # [OPTIONAL] Provides override for repo's working directory
+    # Useful if root git repo contains multiple monorepos
+    working-directory: ""
 ```
 
 <!-- end configuration-options-for-agent-jobs -->


### PR DESCRIPTION
The support for nested repositories via `working-directory` is implemented but not documented.

This PR adds documentation for it.

Fixes #77