### PR TITLE
fix: bump actions to use node 20 versions

### DIFF
--- a/.github/workflows/ci-integration-test-artifacts-multiple-folders.yml
+++ b/.github/workflows/ci-integration-test-artifacts-multiple-folders.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Downloading artifacts"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: custom-artifacts-name
       - run: node -e "if(fs.existsSync('dist/apps/react-app') && fs.existsSync('coverage/apps/react-app')) console.log('Artifacts are here...'); else { throw new Error('Artifacts do not exist!');}"

--- a/.github/workflows/ci-integration-test-artifacts-multiple-folders.yml
+++ b/.github/workflows/ci-integration-test-artifacts-multiple-folders.yml
@@ -39,4 +39,4 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: custom-artifacts-name
-      - run: node -e "if(fs.existsSync('dist/apps/react-app') && fs.existsSync('coverage/apps/react-app')) console.log('Artifacts are here...'); else { throw new Error('Artifacts do not exist!');}"
+      - run: node -e "if(fs.existsSync('dist/react-app') && fs.existsSync('coverage/react-app')) console.log('Artifacts are here...'); else { throw new Error('Artifacts do not exist!');}"

--- a/.github/workflows/ci-integration-test-artifacts-multiple-folders.yml
+++ b/.github/workflows/ci-integration-test-artifacts-multiple-folders.yml
@@ -39,4 +39,4 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: custom-artifacts-name
-      - run: node -e "if(fs.existsSync('dist/react-app') && fs.existsSync('coverage/react-app')) console.log('Artifacts are here...'); else { throw new Error('Artifacts do not exist!');}"
+      - run: node -e "if(fs.existsSync('dist/apps/react-app') && fs.existsSync('coverage/apps/react-app')) console.log('Artifacts are here...'); else { throw new Error('Artifacts do not exist!');}"

--- a/.github/workflows/ci-integration-test-artifacts.yml
+++ b/.github/workflows/ci-integration-test-artifacts.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Downloading artifacts"
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: nx-main-artifacts
           path: dist

--- a/.github/workflows/ci-integration-test-artifacts.yml
+++ b/.github/workflows/ci-integration-test-artifacts.yml
@@ -36,4 +36,4 @@ jobs:
         with:
           name: nx-main-artifacts
           path: dist
-      - run: node -e "if(fs.existsSync('dist/react-app')) console.log('Artifacts are here...'); else { throw new Error('Artifacts do not exist!');}"
+      - run: node -e "if(fs.existsSync('dist/apps/react-app')) console.log('Artifacts are here...'); else { throw new Error('Artifacts do not exist!');}"

--- a/.github/workflows/ci-integration-test-artifacts.yml
+++ b/.github/workflows/ci-integration-test-artifacts.yml
@@ -36,4 +36,4 @@ jobs:
         with:
           name: nx-main-artifacts
           path: dist
-      - run: node -e "if(fs.existsSync('dist/apps/react-app')) console.log('Artifacts are here...'); else { throw new Error('Artifacts do not exist!');}"
+      - run: node -e "if(fs.existsSync('dist/react-app')) console.log('Artifacts are here...'); else { throw new Error('Artifacts do not exist!');}"

--- a/.github/workflows/nx-cloud-agents.yml
+++ b/.github/workflows/nx-cloud-agents.yml
@@ -84,7 +84,7 @@ jobs:
         # Specify shell to help normalize across different operating systems
         shell: bash
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Detect package manager
         id: package_manager
@@ -92,7 +92,7 @@ jobs:
           echo "name=$([[ -f ./yarn.lock ]] && echo "yarn" || ([[ -f ./pnpm-lock.yaml ]] && echo "pnpm") || echo "npm")" >> $GITHUB_OUTPUT
 
       # Set node/npm/yarn versions using volta, with optional overrides provided by the consumer
-      - uses: volta-cli/action@v4
+      - uses: volta-cli/action@master
         with:
           node-version: "${{ inputs.node-version }}"
           npm-version: "${{ inputs.npm-version }}"
@@ -102,7 +102,7 @@ jobs:
       # Install pnpm with exact version provided by consumer or fallback to latest
       - name: Install PNPM
         if: steps.package_manager.outputs.name == 'pnpm'
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: ${{ inputs.pnpm-version }}
           package_json_file: "${{ inputs.working-directory && format('{0}/package.json', inputs.working-directory) || 'package.json' }}"
@@ -124,7 +124,7 @@ jobs:
 
       - name: Use the node_modules cache if available [npm]
         if: steps.package_manager.outputs.name == 'npm'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-${{ hashFiles('**/package-lock.json') }}
@@ -138,7 +138,7 @@ jobs:
 
       - name: Use the node_modules cache if available [pnpm]
         if: steps.package_manager.outputs.name == 'pnpm'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -152,7 +152,7 @@ jobs:
 
       - name: Use the node_modules cache if available [yarn 1.x]
         if: steps.package_manager.outputs.name == 'yarn' && startsWith(steps.versions.outputs.yarn_version, '1.')
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -166,7 +166,7 @@ jobs:
 
       - name: Use the node_modules cache if available [yarn berry]
         if: steps.package_manager.outputs.name == 'yarn' && !startsWith(steps.versions.outputs.yarn_version, '1.')
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-berry-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-yarn-berry-${{ hashFiles('**/yarn.lock') }}
@@ -175,7 +175,7 @@ jobs:
 
       - name: Process environment-variables
         if: ${{ inputs.environment-variables != '' }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         env:
           ENV_VARS: ${{ inputs.environment-variables }}
         with:

--- a/.github/workflows/nx-cloud-agents.yml
+++ b/.github/workflows/nx-cloud-agents.yml
@@ -92,7 +92,7 @@ jobs:
           echo "name=$([[ -f ./yarn.lock ]] && echo "yarn" || ([[ -f ./pnpm-lock.yaml ]] && echo "pnpm") || echo "npm")" >> $GITHUB_OUTPUT
 
       # Set node/npm/yarn versions using volta, with optional overrides provided by the consumer
-      - uses: volta-cli/action@master
+      - uses: volta-cli/action@v4
         with:
           node-version: "${{ inputs.node-version }}"
           npm-version: "${{ inputs.npm-version }}"

--- a/.github/workflows/nx-cloud-main.yml
+++ b/.github/workflows/nx-cloud-main.yml
@@ -120,7 +120,7 @@ jobs:
           echo "name=$([[ -f ./yarn.lock ]] && echo "yarn" || ([[ -f ./pnpm-lock.yaml ]] && echo "pnpm") || echo "npm")" >> $GITHUB_OUTPUT
 
       # Set node/npm/yarn versions using volta, with optional overrides provided by the consumer
-      - uses: volta-cli/action@master
+      - uses: volta-cli/action@v4
         with:
           node-version: "${{ inputs.node-version }}"
           npm-version: "${{ inputs.npm-version }}"

--- a/.github/workflows/nx-cloud-main.yml
+++ b/.github/workflows/nx-cloud-main.yml
@@ -92,7 +92,7 @@ jobs:
         # Specify shell to help normalize across different operating systems
         shell: bash
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout [Pull Request]
         if: ${{ github.event_name == 'pull_request' }}
         with:
@@ -101,7 +101,7 @@ jobs:
           # We need to fetch all branches and commits so that Nx affected has a base to compare against.
           fetch-depth: 0
 
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout [Default Branch]
         if: ${{ github.event_name != 'pull_request' }}
         with:
@@ -109,7 +109,7 @@ jobs:
           fetch-depth: 0
 
       - name: Derive appropriate SHAs for base and head for `nx affected` commands
-        uses: nrwl/nx-set-shas@v3
+        uses: nrwl/nx-set-shas@v4
         with:
           main-branch-name: ${{ inputs.main-branch-name }}
 
@@ -120,7 +120,7 @@ jobs:
           echo "name=$([[ -f ./yarn.lock ]] && echo "yarn" || ([[ -f ./pnpm-lock.yaml ]] && echo "pnpm") || echo "npm")" >> $GITHUB_OUTPUT
 
       # Set node/npm/yarn versions using volta, with optional overrides provided by the consumer
-      - uses: volta-cli/action@v4
+      - uses: volta-cli/action@master
         with:
           node-version: "${{ inputs.node-version }}"
           npm-version: "${{ inputs.npm-version }}"
@@ -130,7 +130,7 @@ jobs:
       # Install pnpm with exact version provided by consumer or fallback to latest
       - name: Install PNPM
         if: steps.package_manager.outputs.name == 'pnpm'
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v3
         with:
           version: ${{ inputs.pnpm-version }}
           package_json_file: "${{ inputs.working-directory && format('{0}/package.json', inputs.working-directory) || 'package.json' }}"
@@ -152,7 +152,7 @@ jobs:
 
       - name: Use the node_modules cache if available [npm]
         if: steps.package_manager.outputs.name == 'npm'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-${{ hashFiles('**/package-lock.json') }}
@@ -166,7 +166,7 @@ jobs:
 
       - name: Use the node_modules cache if available [pnpm]
         if: steps.package_manager.outputs.name == 'pnpm'
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.pnpm-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -180,7 +180,7 @@ jobs:
 
       - name: Use the node_modules cache if available [yarn 1.x]
         if: steps.package_manager.outputs.name == 'yarn' && startsWith(steps.versions.outputs.yarn_version, '1.')
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-yarn-${{ hashFiles('**/yarn.lock') }}
@@ -194,7 +194,7 @@ jobs:
 
       - name: Use the node_modules cache if available [yarn berry]
         if: steps.package_manager.outputs.name == 'yarn' && !startsWith(steps.versions.outputs.yarn_version, '1.')
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-berry-cache-dir-path.outputs.dir }}
           key: ${{ runner.os }}-node-${{ steps.versions.outputs.node_version }}-yarn-berry-${{ hashFiles('**/yarn.lock') }}
@@ -203,7 +203,7 @@ jobs:
 
       - name: Process environment-variables
         if: ${{ inputs.environment-variables != '' }}
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         env:
           ENV_VARS: ${{ inputs.environment-variables }}
         with:
@@ -269,7 +269,7 @@ jobs:
       # are local to this repo which defines the workflow, and we therefore need to work around this by embedding the contents
       # of the shell utilities for executing commands into the workflow directly.
       - name: Create command utils
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const { writeFileSync } = require('fs');
@@ -310,7 +310,7 @@ jobs:
           ${{ inputs.init-commands }}
 
       - name: Process parallel commands configuration
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         id: parallel_commands_config
         env:
           PARALLEL_COMMANDS: ${{ inputs.parallel-commands }}
@@ -366,7 +366,7 @@ jobs:
           ${{ inputs.final-commands }}
 
       - name: Uploading artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: ${{ inputs.artifacts-path != '' }}
         with:
           name: ${{ inputs.artifacts-name }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - uses: jameshenry/publish-shell-action@v1
         with:

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "private": true,
-  "version": "0.14.0",
+  "version": "0.15.0",
   "description": "This package.json is here purely to control the version of the Action, in combination with https://github.com/JamesHenry/publish-shell-action"
 }


### PR DESCRIPTION
Voltas doesnt have a numbered version out yet, but master has been updated to use node20